### PR TITLE
Prepare for the 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 1.1.0 - 2019-04-xx
+
+Removed the lock down from the dependent gems in order to make the gem
+compatible with Active Model 5.x.x and Bundler 2.x.x.
+
+## 1.0.2 - 2018-11-14
+
+- Added `Hetu.generate` method for valid random PIN generation
+- Code cleanup and refactoring
+
+## 1.0.1 - Unreleased
+
+Added dependency constraints for the `minitest`, `timecop` and `activemodel`
+gems.
+
+## 1.0.0 - 2015-10-08
+
+Initial release.

--- a/lib/henkilotunnus/version.rb
+++ b/lib/henkilotunnus/version.rb
@@ -1,3 +1,3 @@
 module Henkilotunnus
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
- Bumps version number to `1.1.0` since there are potentially breaking changes with the dependencies.
- Add CHANGELOG.md to track the changes between the releases